### PR TITLE
feat: better tile intersection

### DIFF
--- a/src/main/java/com/technicjelle/bluemapareacontrol/Area.java
+++ b/src/main/java/com/technicjelle/bluemapareacontrol/Area.java
@@ -6,13 +6,11 @@ import de.bluecolored.bluemap.api.markers.ShapeMarker;
 public interface Area {
 	boolean isValid();
 
-	void calculateTilePositions(BlueMapMap map);
+	void forMap(BlueMapMap map);
 
 	boolean containsTile(int tx, int tz);
 
 	String debugString();
 
 	ShapeMarker createBlockMarker(BlueMapMap map);
-
-	ShapeMarker createTileMarker(BlueMapMap map);
 }

--- a/src/main/java/com/technicjelle/bluemapareacontrol/AreaRect.java
+++ b/src/main/java/com/technicjelle/bluemapareacontrol/AreaRect.java
@@ -1,12 +1,14 @@
 package com.technicjelle.bluemapareacontrol;
 
+import org.spongepowered.configurate.objectmapping.ConfigSerializable;
+import org.spongepowered.configurate.objectmapping.meta.Comment;
+
 import com.flowpowered.math.vector.Vector2i;
+
 import de.bluecolored.bluemap.api.BlueMapMap;
 import de.bluecolored.bluemap.api.markers.ShapeMarker;
 import de.bluecolored.bluemap.api.math.Color;
 import de.bluecolored.bluemap.api.math.Shape;
-import org.spongepowered.configurate.objectmapping.ConfigSerializable;
-import org.spongepowered.configurate.objectmapping.meta.Comment;
 
 @ConfigSerializable
 public class AreaRect implements Area {
@@ -49,13 +51,13 @@ public class AreaRect implements Area {
 	}
 
 	@Override
-	public void calculateTilePositions(BlueMapMap map) {
-		Vector2i pos = map.posToTile(x1, z1);
-		tx1 = pos.getX();
-		tz1 = pos.getY();
-		Vector2i size = map.posToTile(x2, z2);
-		tx2 = size.getX();
-		tz2 = size.getY();
+	public void forMap(BlueMapMap map) {
+		Vector2i pos1 = map.posToTile(x1, z1);
+		tx1 = pos1.getX();
+		tz1 = pos1.getY();
+		Vector2i pos2 = map.posToTile(x2, z2);
+		tx2 = pos2.getX();
+		tz2 = pos2.getY();
 	}
 
 	@Override
@@ -77,24 +79,6 @@ public class AreaRect implements Area {
 				.depthTestEnabled(false)
 				.lineColor(new Color(0, 0, 255, 1f))
 				.fillColor(new Color(0, 0, 200, 0.3f))
-				.build();
-	}
-
-	@Override
-	public ShapeMarker createTileMarker(BlueMapMap map) {
-		Vector2i tileSize = map.getTileSize();
-		int sx = tileSize.getX();
-		int sz = tileSize.getY();
-		Vector2i tileOffset = map.getTileOffset();
-		int ox = tileOffset.getX();
-		int oz = tileOffset.getY();
-		Shape shape = Shape.createRect(ox+tx1*sx, oz+tz1*sz, ox+(tx2+1)*sx, oz+(tz2+1)*sz);
-		return ShapeMarker.builder()
-				.label(debugString())
-				.shape(shape, 1)
-				.depthTestEnabled(false)
-				.lineColor(new Color(255, 0, 0, 1f))
-				.fillColor(new Color(200, 0, 0, 0.3f))
 				.build();
 	}
 }

--- a/src/main/java/com/technicjelle/bluemapareacontrol/BlueMapAreaControl.java
+++ b/src/main/java/com/technicjelle/bluemapareacontrol/BlueMapAreaControl.java
@@ -1,16 +1,5 @@
 package com.technicjelle.bluemapareacontrol;
 
-import com.technicjelle.UpdateChecker;
-import de.bluecolored.bluemap.api.BlueMapAPI;
-import de.bluecolored.bluemap.api.BlueMapMap;
-import de.bluecolored.bluemap.api.markers.MarkerSet;
-import org.bstats.bukkit.Metrics;
-import org.bukkit.plugin.java.JavaPlugin;
-import org.jetbrains.annotations.NotNull;
-import org.spongepowered.configurate.CommentedConfigurationNode;
-import org.spongepowered.configurate.ConfigurationNode;
-import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
-
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -20,6 +9,19 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Consumer;
+
+import org.bstats.bukkit.Metrics;
+import org.bukkit.plugin.java.JavaPlugin;
+import org.jetbrains.annotations.NotNull;
+import org.spongepowered.configurate.CommentedConfigurationNode;
+import org.spongepowered.configurate.ConfigurationNode;
+import org.spongepowered.configurate.hocon.HoconConfigurationLoader;
+
+import com.technicjelle.UpdateChecker;
+
+import de.bluecolored.bluemap.api.BlueMapAPI;
+import de.bluecolored.bluemap.api.BlueMapMap;
+import de.bluecolored.bluemap.api.markers.MarkerSet;
 
 public final class BlueMapAreaControl extends JavaPlugin {
 	private UpdateChecker updateChecker;
@@ -106,7 +108,7 @@ public final class BlueMapAreaControl extends JavaPlugin {
 				List<? extends ConfigurationNode> children = areasNode.childrenList();
 				for (ConfigurationNode child : children) {
 					Area area = getArea(child);
-					area.calculateTilePositions(map);
+					area.forMap(map);
 					areas.add(area);
 				}
 			} catch (Exception e) {
@@ -127,8 +129,7 @@ public final class BlueMapAreaControl extends JavaPlugin {
 
 				for (Area area : areas) {
 					getLogger().info('\t' + area.debugString());
-					markerSet.put(area.debugString() + "tile" + area, area.createTileMarker(map));
-//					markerSet.put(area.debugString() + "block" + area, area.createBlockMarker(map));
+					markerSet.put(area.debugString() + "block" + area, area.createBlockMarker(map));
 				}
 			}
 


### PR DESCRIPTION
I do believe the old way of converting to tiles and just selecting tiles fully inside it is wrong- rather select all tiles required to fully select the area user expects to be hidden / shown.
Ignore IDE sorting imports, couldn't be bothered to revert.
Old | New
--- | ---
![image](https://user-images.githubusercontent.com/45627874/236202331-aa355839-79f5-48fd-8e95-f9f9b9949950.png) | ![image](https://user-images.githubusercontent.com/45627874/236202357-906c2a78-81c4-482d-b45f-dfc30aba657a.png)
